### PR TITLE
Set default graph node color and style based on its category

### DIFF
--- a/src/core/concept_node.gd
+++ b/src/core/concept_node.gd
@@ -337,6 +337,21 @@ func _setup_slots() -> void:
 
 
 """
+Based on graph node category this method will setup corresponding style and color of graph node
+"""
+func _generate_default_gui_style() -> void:
+	var style = StyleBoxFlat.new()
+	var color = Color(0.121569, 0.145098, 0.192157, 0.9)
+	style.border_color = ConceptGraphDataType.to_category_color(category)
+	style.set_bg_color(color)
+	style.set_border_width_all(1)
+	style.set_border_width(MARGIN_TOP, 24)
+	style.content_margin_left = 24;
+	style.content_margin_right = 24;
+	add_stylebox_override("frame", style)
+	add_constant_override("port_offset", 12)
+
+"""
 If the child node does not define a custom UI itself, this function will generate a default UI
 based on the parameters provided with set_input and set_ouput. Each slots will have a Label
 and their name attached.
@@ -352,6 +367,9 @@ func _generate_default_gui() -> void:
 		remove_child(box)
 		box.queue_free()
 	_hboxes = []
+
+	_generate_default_gui_style()
+
 	title = display_name
 	resizable = false
 	show_close = true

--- a/src/data_structures/data_types.gd
+++ b/src/data_structures/data_types.gd
@@ -39,6 +39,36 @@ const COLORS = {
 	MATH_CURVE: Color.dodgerblue,
 }
 
+"""
+Convert graph node category name to color
+"""
+static func to_category_color(category: String) -> Color:
+	match category:
+		"Boxes":
+			return COLORS[BOX]
+		"Curves", "Curves/Inputs", "Curves/Operations", "Curves/Conversion", "Curves/Generators":
+			return COLORS[CURVE]
+		"Debug":
+			return Color.palegreen
+		"Inputs":
+			return Color("8ca6f4")
+		"Inspector properties":
+			return Color.navyblue
+		"Maths/Scalars":
+			return COLORS[SCALAR]
+		"Meshes":
+			return COLORS[MESH]
+		"Nodes/Generators", "Nodes/Operations", "Nodes/Instancers":
+			return COLORS[NODE]
+		"Noise":
+			return Color.olive#COLORS[NOISE]
+		"Output":
+			return Color.black
+		"Vectors":
+			return COLORS[VECTOR]
+		_:
+			return Color.black
+
 
 """
 Allows extra connections between different types


### PR DESCRIPTION
It is easier to navigate when nodes have colors depending on the category
![Screenshot from 2020-05-02 14-54-26](https://user-images.githubusercontent.com/1286923/80864749-e42dcd00-8c84-11ea-9ca7-6119e91f202f.png)
