### PR TITLE
Add comment graph node

### DIFF
--- a/src/nodes/comment.gd
+++ b/src/nodes/comment.gd
@@ -1,0 +1,31 @@
+tool
+extends ConceptNode
+
+
+func _init() -> void:
+	unique_id = "comment"
+	display_name = "Comment"
+	category = "Utilities"
+	description = "Insert comment in concept graph editor"
+	resizable = true
+
+
+func export_custom_data() -> Dictionary:
+	return {"comment_text": $LineEditComment.text}
+
+
+func restore_custom_data(data: Dictionary) -> void:
+	if not data.has("comment_text"):
+		return
+	$LineEditComment.text = data["comment_text"]
+
+
+func has_custom_gui() -> bool:
+	return true
+
+
+"""
+Emmit signal for saving data, when comment was changed
+"""
+func _on_LineEditComment_text_changed(new_text: String) -> void:
+	emit_signal("node_changed", self, false)

--- a/src/nodes/comment.tscn
+++ b/src/nodes/comment.tscn
@@ -1,0 +1,54 @@
+[gd_scene load_steps=4 format=2]
+
+[ext_resource path="res://addons/concept_graph/src/nodes/comment.gd" type="Script" id=1]
+
+[sub_resource type="StyleBoxFlat" id=1]
+content_margin_left = 5.0
+content_margin_right = 20.0
+content_margin_top = 24.0
+draw_center = false
+border_width_left = 2
+border_width_top = 20
+border_width_right = 2
+border_width_bottom = 2
+border_color = Color( 0.27451, 0.478431, 0.792157, 1 )
+border_blend = true
+
+[sub_resource type="StyleBoxEmpty" id=2]
+
+[node name="GraphNode" type="GraphNode"]
+margin_left = 14.9937
+margin_top = 15.5046
+margin_right = 266.994
+margin_bottom = 140.505
+rect_clip_content = true
+custom_styles/commentfocus = SubResource( 1 )
+custom_styles/comment = SubResource( 1 )
+custom_styles/frame = SubResource( 1 )
+custom_constants/close_offset = 20
+show_close = true
+resizable = true
+comment = true
+slot/0/left_enabled = false
+slot/0/left_type = 0
+slot/0/left_color = Color( 0, 0, 0, 0 )
+slot/0/right_enabled = false
+slot/0/right_type = 0
+slot/0/right_color = Color( 0, 0, 0, 0 )
+script = ExtResource( 1 )
+__meta__ = {
+"_edit_use_anchors_": false
+}
+
+[node name="LineEditComment" type="LineEdit" parent="."]
+margin_left = 5.0
+margin_top = 24.0
+margin_right = 232.0
+margin_bottom = 48.0
+rect_min_size = Vector2( 0, 24 )
+size_flags_horizontal = 3
+size_flags_vertical = 3
+custom_styles/normal = SubResource( 2 )
+placeholder_text = "Write your comment.."
+caret_blink = true
+[connection signal="text_changed" from="LineEditComment" to="." method="_on_LineEditComment_text_changed"]


### PR DESCRIPTION
Simple comment node (with few workarounds).
#7 
![Screenshot from 2020-05-03 23-30-23](https://user-images.githubusercontent.com/1286923/80926355-17f91780-8d97-11ea-86ff-8b02bd977cbe.png)
