### PR TITLE
Allow to be compiled headlessly in a Docker container

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,15 +22,22 @@ script_templates/
 .mono/
 # data_*/
 
-# Build specific ignores
+# Large files + build artifacts
 bin/*
 builds/osx/*.app
 builds/godot.*
 builds/osx/release.dmg
+builds/linux/*.*
+builds/server/*
 godot*
-librdkafka.tres
-librdkafka.gdns
 !native/thirdparty/librdkafka/librdkafka.*
+templates*
+headless.tmp
+librdkafka.gdns
+librdkafka.prod.gdns
+librdkafka.prod.tres
+*/**/librdkafka.so.1
+librdkafka.so.1
 
 *.o
 *.os

--- a/.gitignore
+++ b/.gitignore
@@ -38,6 +38,8 @@ librdkafka.prod.gdns
 librdkafka.prod.tres
 */**/librdkafka.so.1
 librdkafka.so.1
+linux.zip
+osx.zip
 
 *.o
 *.os

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,35 @@
+FROM ubuntu:20.04
+
+# Alter sources list so that we can find gcc-4.9
+RUN cd /etc/apt && echo 'deb http://dk.archive.ubuntu.com/ubuntu/ xenial main\n' >> sources.list && echo 'deb http://dk.archive.ubuntu.com/ubuntu/ xenial universe\n' >> sources.list && cd -
+
+# Make sure that we have add-apt-repository available
+RUN apt-get -y -o Acquire::ForceIPv4=true update
+RUN apt-get install software-properties-common -y
+
+# Tooling to support running the programme
+RUN add-apt-repository ppa:ubuntu-toolchain-r/test -y
+RUN apt-get -y -o Acquire::ForceIPv4=true update && apt-get install -y gcc-4.9 && apt-get upgrade -y libstdc++6
+RUN apt-get dist-upgrade -y
+
+# Packages for runtime execution
+RUN apt-get -y -o Acquire::ForceIPv4=true update && apt -y -o Acquire::ForceIPv4=true install xvfb libxcursor-dev libxinerama1 libxrandr2 libxi6 libasound2 libpulse0 libgl1-mesa-glx
+# ELF utils
+RUN apt-get -y install binutils elfutils patchelf
+# Additional utils for runtime execution
+RUN apt-get -y install curl
+# Copy the headless binary + pck
+COPY builds/server /usr/protongraph
+# Copy the native resources (basically just compiled Kafka library for now)
+COPY native/thirdparty/librdkafka/librdkafka.gdns /usr/protongraph/native/thirdparty/librdkafka/librdkafka.gdns
+COPY native/thirdparty/librdkafka/librdkafka.tres /usr/protongraph/native/thirdparty/librdkafka/librdkafka.tres
+COPY native/thirdparty/librdkafka/bin/x11/librdkafka.so /usr/protongraph/native/thirdparty/librdkafka/bin/x11/librdkafka.so
+COPY native/thirdparty/librdkafka/bin/x11/librdkafka.so.1 /usr/protongraph/native/thirdparty/librdkafka/bin/x11/librdkafka.so.1
+
+# Copy the hyper-important config files across; without these we can't connect to Kafka
+COPY config /usr/protongraph/config
+WORKDIR /usr/protongraph
+
+# Hack sourced from here to work around X11 requirement: https://github.com/godotengine/godot/issues/18171#issuecomment-383058814
+CMD xvfb-run -a -n 55 -s "-screen 0 1400x900x24 -ac +extension GLX +render -noreset" ./headless --audio-driver Dummy --display-driver headless
+EXPOSE 4347

--- a/Dockerfile.compile
+++ b/Dockerfile.compile
@@ -1,0 +1,22 @@
+FROM gcc:latest
+
+# Basic packages
+RUN apt-get -y -o Acquire::ForceIPv4=true update
+RUN apt-get install -y make scons g++
+RUN apt-get install -y wget unzip vim
+RUN apt-get install -y binutils elfutils patchelf
+
+# Set working directory
+RUN mkdir -p /usr/src/myapp
+WORKDIR /usr/src/myapp
+
+# We need these for compilation
+RUN wget https://downloads.tuxfamily.org/godotengine/3.4.2/Godot_v3.4.2-stable_linux_headless.64.zip && unzip Godot_v3.4.2-stable_linux_headless.64.zip && mv Godot_v3.4.2-stable_linux_headless.64 godot.linux.3.4.2-stable.headless.64
+RUN wget https://downloads.tuxfamily.org/godotengine/3.4.2/Godot_v3.4.2-stable_export_templates.tpz && unzip Godot_v3.4.2-stable_export_templates.tpz
+RUN mkdir -p ~/.local/share/godot/templates/3.4.2.stable
+RUN cd templates && cp * ~/.local/share/godot/templates/3.4.2.stable && cd -
+
+# Copy the native resources
+COPY native/thirdparty/librdkafka/librdkafka.gdns librdkafka.gdns
+COPY native/thirdparty/librdkafka/librdkafka.tres librdkafka.prod.tres
+

--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+#!/bin/bash
 CHECK_FILES+=
 
 DOC_FILES+=	README.md
@@ -14,6 +15,10 @@ MKL_COPYRIGHT_SKIP?=^(tests|packaging)
 OUTPUT= ProtonGraph
 OUTPUT_DMG= builds/osx/release.dmg
 GODOT_BINARY= godot.osx.3.4.2-stable.tools.64
+GODOT_EXPORT_TO_HEADLESS_BINARY= godot.osx.3.4.3-stable.tools.server.64
+DOCKER_EXPORT_TO_HEADLESS_BINARY= godot.linux.3.4.2-stable.headless.64
+
+LIBRDKAFKA_DIR= native/thirdparty/librdkafka/lib
 
 define RUN_CMAKE
 	echo $(1) && mkdir $(1)/build && cd $(1)/build && cmake .. && cd -
@@ -21,14 +26,20 @@ endef
 
 .PHONY:
 
-all: mklove-check compile copy_compiled_files godot_export package
-
-post_compile: mklove-check copy_compiled_files godot_export package
+# Build within docker container for separate docker process
+all: mklove-check build_rdkafka compile_linux docker_export_linux
+# Build on osx for osx
+osx: mklove-check build_rdkafka compile_osx godot_export_osx package_osx
+# Build on osx for docker process
+docker: mklove-check build_rdkafka compile_linux godot_export_linux package_docker
 
 include mklove/Makefile.base
 
+build_rdkafka:
+	pushd $(LIBRDKAFKA_DIR); ./configure && make; popd
+
 # nb. this is currently specific to osx. Ideally we should be able to package for linux and windows as well.
-package:
+package_osx:
 	mkdir -p bin/protongraph.app/Contents/MacOS/ || echo "build directory already exists"
 	mkdir -p bin/ProtonGraph.app/Contents/MacOS/config/secrets || echo "secrets directory already exists"
 	rm -r bin/protongraph.app/Contents/MacOS/config/secrets || echo "kafka secrets not found"
@@ -38,20 +49,43 @@ package:
 	cp build/launch bin/protongraph.app/Contents/MacOS/
 	cp native/thirdparty/librdkafka/librdkafka.gdns bin/ProtonGraph.app/Contents/MacOS/librdkafka.gdns
 	cp native/thirdparty/librdkafka/librdkafka.tres bin/ProtonGraph.app/Contents/MacOS/librdkafka.tres
+	cp build/Info.plist bin/protongraph.app/Contents/Info.plist
 	cp native/thirdparty/librdkafka/bin/osx/librdkafka.1.dylib bin/protongraph.app/Contents/MacOS/
 	cp native/thirdparty/librdkafka/bin/osx/librdkafka.dylib bin/protongraph.app/Contents/MacOS/
 	cp native/thirdparty/mesh_optimizer/bin/osx/libmeshoptimizer.dylib bin/protongraph.app/Contents/MacOS/
 
+package_docker:
+	docker build . -t protongraph
 # Evidently this is currently specific to osx, one presumably would want to generalise this to windows and linux as well.
-godot_export:
+godot_export_osx:
 	./$(GODOT_BINARY) --path . --no-window --quiet --export "osx"
 	./extract_app.sh
 
-compile:
+# Nb, this presupposes that you are exporting in server-mode (headless) to linux from a custom build of godot (built off tag 3.4.3-stable).
+# To obtain said custom build, you need to run the following commands:
+# #godot> git checkout 3.4.3-stable
+# #godot> scons platform=server tools=yes target=release_debug --jobs=$(sysctl -n hw.logicalcpu)
+# #godot> cp bin/godot_server.osx.opt.tools.64 /<PATH_TO_PROTONGRAPH_ON_YOUR_MACHINE>/protongraph/godot.osx.3.4.3-stable.tools.server.64
+godot_export_linux:
+	pushd ~/.local/share/godot/templates/3.4.3.stable; ln -s ~/Library/Application Support/Godot/templates/3.4.3.stable; popd
+	cp native/thirdparty/librdkafka/bin/x11/librdkafka.so ./
+	cp native/thirdparty/mesh_optimizer/bin/x11/libmeshoptimizer.so ./
+	./$(GODOT_EXPORT_TO_HEADLESS_BINARY) --path . --no-window --display-driver headless --quiet --export "server"
+	mv headless builds/server
+	mv headless.pck builds/server
+
+docker_export_linux:
+	cp native/thirdparty/librdkafka/bin/x11/librdkafka.so ./
+	cp native/thirdparty/librdkafka/bin/x11/librdkafka.so.1 ./
+	cp native/thirdparty/mesh_optimizer/bin/x11/libmeshoptimizer.so ./
+	cp native/thirdparty/librdkafka/librdkafka.gdns librdkafka.gdns
+	cp native/thirdparty/librdkafka/librdkafka.tres librdkafka.prod.tres
+	./$(DOCKER_EXPORT_TO_HEADLESS_BINARY) --path . --no-window --display-driver headless --quiet --export "server"
+	mv headless builds/server
+	mv headless.pck builds/server
+
+compile_osx:
 	pushd native; ./compile_all.sh osx release; popd
 
-copy_compiled_files:
-	cp native/thirdparty/librdkafka/librdkafka.gdns librdkafka.gdns
-	cp native/thirdparty/librdkafka/librdkafka.tres librdkafka.tres
-	cp native/thirdparty/librdkafka/bin/osx/librdkafka.dylib librdkafka.dylib
-	cp native/thirdparty/librdkafka/bin/osx/librdkafka.1.dylib librdkafka.1.dylib
+compile_linux:
+	pushd native; ./compile_all.sh linux release; popd

--- a/README.md
+++ b/README.md
@@ -35,10 +35,33 @@ on how to actually use the software, tutorials and example files.
 
 + To track the work in progress and planned features, [head over the project board](https://github.com/proton-graph/proton-graph/projects)
 
+### Read me first
 
-## Build from source
-If you want to build the project from source yourself, you will need a custom version of the engine.
-Follow the instructions on this repository: https://github.com/proton-graph/environment.
+If you want to build the project from source yourself, first read the instructions on this repository: https://github.com/proton-graph/environment.  Note: Originally Protongraph required a custom build of the Godot game engine, but this is no longer required as of Godot 3.4.x.  You will still need to build the engine from source though if you want to compile from command line, see [here](https://docs.godotengine.org/en/stable/development/compiling/index.html) for a guide on how to do this.
+
+(Note that as of writing Protongraph supports building for Godot 3.4.2, and work to migrate Protongraph to Godot 4 is currently in progress.)
+
+Once you have a built Godot binary you'll want to move it to the root of the Protongraph directory.  Currently the project Makefile assumes that this binary will be labelled `godot.osx.3.4.2-stable.tools.64`.  Note that `make` will not work unless you have this binary available.
+
+You'll also want the export templates for 3.4.2 as well, you can find them [here](https://downloads.tuxfamily.org/godotengine/3.4.2/).  These templates should be placed in the build folder.
+
+Downloading a built version of the Godot binary will not work as the officially compiled versions do not have tools enabled, you will need either to build from source yourself or source the file from an unofficial build repository.
+
+### Making the project
+
+To build for Docker, ensure that you have the headless binary for linux, `godot.linux.3.4.2-stable.headless.64`.  You can obtain this from [here](https://downloads.tuxfamily.org/godotengine/3.4.2/), it will be the debug server build.  Note that you will need to rename the binary.
+
+Then run `./compile.sh` (do not run `make`).  After this, `./scripts/start.sh` will start the process, and `./scripts/stop.sh` will stop it.  `./scripts/debug.sh` will provide a prompt inside the running container.
+
+Alternatively if you wish to build for OSX, ensure that you have the binary for osx, `godot.osx.3.4.2-stable.tools.64`, then run `make osx`.  Note that the compiled binary obtained via this approach does not support Kafka at present.
+
+### Further particulars
+
+Protongraph has two modes of operation being Default responder mode, and Kafka producer mode.  Default responder mode responds along the Websocket connection that sync-godot establishes with Protongraph via the Godot engine client.  In this mode, packets are sent back and forth directly between the Godot engine and Protongraph via Websocket.
+
+In Kafka producer mode, Protongraph writes messages it receives via a Websocket connection to a Kafka topic instead.  This mode is useful for instance if Protongraph is deployed to the cloud, and there are up to several additional network hops between the running Godot game and Protongraph, eg Godot game -> Signalling server -> Kafka topic -> Kafka consumer -> Protongraph.  In this instance, the output work from Protongraph would return to the Godot game in potentially a 1 to many relationship via eg Protongraph -> Kafka topic -> Signalling server -> { set of networked clients running the Godot game }.
+
+For more information see `config/Readme.md`.
 
 ## Social medias
 

--- a/common/autoloads/lib/server.gd
+++ b/common/autoloads/lib/server.gd
@@ -11,7 +11,11 @@ var _incoming = {}
 
 
 func _ready() -> void:
-	_ws.set_bind_ip("127.0.0.1")
+	# If we set this to localhost then when running headlessly in docker we can't connect to it
+	# from outside the running container, so leave as default wildcard IP instead.
+	# ref: https://docs.godotengine.org/en/stable/classes/class_websocketserver.html#property-descriptions
+	# ref: https://stackoverflow.com/a/54102318/1979000
+	# _ws.set_bind_ip("127.0.0.1")
 	Signals.safe_connect(_ws, "client_connected", self, "_on_client_connected")
 	Signals.safe_connect(_ws, "client_disconnected", self, "_on_client_disconnected")
 	Signals.safe_connect(_ws, "client_close_request", self, "_on_client_close_request")

--- a/common/autoloads/project_settings.gd
+++ b/common/autoloads/project_settings.gd
@@ -35,7 +35,7 @@ var _require_restart := [
 
 
 func _ready() -> void:
-	pass
+	load_or_create_config()
 
 func has(setting: String) -> bool:
 	return _settings.has(setting)

--- a/common/autoloads/project_settings.gd
+++ b/common/autoloads/project_settings.gd
@@ -35,8 +35,7 @@ var _require_restart := [
 
 
 func _ready() -> void:
-	load_or_create_config()
-
+	pass
 
 func has(setting: String) -> bool:
 	return _settings.has(setting)

--- a/common/autoloads/protocol.gd
+++ b/common/autoloads/protocol.gd
@@ -6,8 +6,9 @@ var _node_serializer: NodeSerializer
 var librdkafka
 
 func _init():
-	librdkafka = load("res://librdkafka.gdns").new()
-	librdkafka.produce("look at me i'm writing to kafka")
+	librdkafka = load("res://native/thirdparty/librdkafka/librdkafka.gdns").new()
+	# If you'd like to test producing to Kafka, try this:
+	# librdkafka.produce("look at me i'm writing to kafka")
 
 func _ready():
 	if not _node_serializer:

--- a/common/autoloads/protocol.gd
+++ b/common/autoloads/protocol.gd
@@ -125,10 +125,17 @@ func _on_data_received(id: int , data: Dictionary) -> void:
 # as well as several optional values.
 func _on_remote_build_requested(id, msg: Dictionary) -> void:
 	print("[IPC] Remote build requested")
-	if not msg.has("path"):
+	var path: String
+	var tpgn: String
+	if not msg.has("path") and not msg.has("tpgn"):
+		print("[IPC] Remote build requested, but missing path and tpgn")
 		return
-
-	var path: String = msg["path"]
+	if msg.has("tpgn"):
+		tpgn = msg["tpgn"]
+		path = ""
+	elif msg.has("path"):
+		path = msg["path"]
+		tpgn = ""
 	var inspector: Array = msg["inspector"] if msg.has("inspector") else null
 	var generator_payload_data_array := []
 	var generator_resources_data_array := []
@@ -141,7 +148,7 @@ func _on_remote_build_requested(id, msg: Dictionary) -> void:
 		"generator_payload_data_array": generator_payload_data_array,
 		"generator_resources_data_array": generator_resources_data_array
 	}
-	GlobalEventBus.dispatch("build_for_remote", [id, path, args])
+	GlobalEventBus.dispatch("build_for_remote", [id, path, tpgn, args])
 
 
 func _on_remote_build_completed(id, data: Array) -> void:

--- a/common/autoloads/protocol.gd
+++ b/common/autoloads/protocol.gd
@@ -35,96 +35,10 @@ func _on_data_received(id: int , data: Dictionary) -> void:
 		"build":
 			_on_remote_build_requested(id, data)
 
-# Input msg for the fence.tpgn graph will take the following form:
-# {
-# 	command:build, 
-# 	inputs: [{
-# 		node: [{
-# 			data: {
-# 				points: [
-# 					{ in:[0, 0, 0], out:[0, 0, 0], pos:[-4.35923, 0, -3.58755], tilt:0 }, 
-# 					{ in:[-3.83067, -0.005032, -0.890189], out:[3.83067, 0.005032, 0.890189], pos:[1.26936, 0.002264, -4.18087], tilt:0 }, 
-# 					{ in:[0.210581, 0, -1.57824], out:[-0.210581, 0, 1.57824], pos:[5.66448, 0, 1.26848], tilt:0 },
-# 					{ in:[0, 0, 0], out:[0, 0, 0], pos:[4.15667, 0, 4.50781], tilt:0 }
-# 				], 
-# 				transform: {
-# 					basis:[[1, 0, 0], [0, 1, 0], [0, 0, 1]], 
-# 					pos:[0, 0, 0]
-# 				}
-# 			}, 
-# 			name:Path,
-#			node_path_input:{Path:/root/EditorNode/@@592/@@593/@@601/@@603/@@607/@@611/@@612/@@613/@@629/@@630/@@639/@@640/@@6275/@@6109/@@6110/@@6111/@@6112/@@6113/TestProtongraph/Fence/Inputs/Path}
-# 			type:curve_3d
-# 		},
-# 		{
-# 			children:[{
-# 				children:[{
-# 					data:{
-# 						mesh:{
-# 							0:[[[ ... ]], Null, Null, Null, [ ... ]] /// (see below)
-# 						},
-# 						resource_path:res://assets/fences/models/fence_planks.glb::2,
-# 						transform:{
-# 							basis:[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
-# 							pos:[0, -0.05, 0]
-# 						}
-# 					},
-# 					name:fence_planks,
-#					node_path_input:{fence_planks:/root/EditorNode/@@592/@@593/@@601/@@603/@@607/@@611/@@612/@@613/@@629/@@630/@@639/@@640/@@6275/@@6109/@@6110/@@6111/@@6112/@@6113/TestProtongraph/Fence/Inputs/fence_planks/tmpParent/fence_planks}
-# 					type:mesh
-# 				}],
-# 				data: {
-# 					transform: {
-# 						basis:[[1, 0, 0], [0, 1, 0], [0, 0, 1]], pos:[0, 0, 0]
-# 					}
-# 				},
-# 				name:tmpParent,
-#				node_path_input:{tmpParent:/root/EditorNode/@@592/@@593/@@601/@@603/@@607/@@611/@@612/@@613/@@629/@@630/@@639/@@640/@@6275/@@6109/@@6110/@@6111/@@6112/@@6113/TestProtongraph/Fence/Inputs/fence_planks/tmpParent}
-# 				type:node_3d
-# 			}],
-# 			data: {
-# 				transform: {
-# 					basis:[[1, 0, 0], [0, 1, 0], [0, 0, 1]], pos:[0, 0, 0]
-# 				}
-# 			},
-# 			name:fence_planks,
-#			node_path_input:{fence_planks:/root/EditorNode/@@592/@@593/@@601/@@603/@@607/@@611/@@612/@@613/@@629/@@630/@@639/@@640/@@6275/@@6109/@@6110/@@6111/@@6112/@@6113/TestProtongraph/Fence/Inputs/fence_planks}
-# 			type:node_3d
-# 		}], 
-# 		resources:[{
-#			name:Path, 
-#			node_path_input:{
-#				Path:/root/EditorNode/@@592/@@593/@@601/@@603/@@607/@@611/@@612/@@613/@@629/@@630/@@639/@@640/@@6275/@@6109/@@6110/@@6111/@@6112/@@6113/TestProtongraph/Fence/Inputs/Path
-#			}
-#		}, 
-#		{
-#			children:[{
-#				children:[{
-#					name:fence_planks, 
-#					node_path_input:{
-#						fence_planks:/root/EditorNode/@@592/@@593/@@601/@@603/@@607/@@611/@@612/@@613/@@629/@@630/@@639/@@640/@@6275/@@6109/@@6110/@@6111/@@6112/@@6113/TestProtongraph/Fence/Inputs/fence_planks/tmpParent/fence_planks
-#					}
-#				}],
-#				name:tmpParent,
-#				node_path_input:{
-#					tmpParent:/root/EditorNode/@@592/@@593/@@601/@@603/@@607/@@611/@@612/@@613/@@629/@@630/@@639/@@640/@@6275/@@6109/@@6110/@@6111/@@6112/@@6113/TestProtongraph/Fence/Inputs/fence_planks/tmpParent
-#				}
-#			}],
-#			name:fence_planks,
-#			node_path_input:{
-#				fence_planks:/root/EditorNode/@@592/@@593/@@601/@@603/@@607/@@611/@@612/@@613/@@629/@@630/@@639/@@640/@@6275/@@6109/@@6110/@@6111/@@6112/@@6113/TestProtongraph/Fence/Inputs/fence_planks
-#			}
-#		}]
-# 	}],
-# 	inspector:[],
-# 	path:/Users/Chris/code/token-cjg/TestProtongraphProject/templates/fence.tpgn
-# }
-#
-#
-# Where 0:[[[ ... ]], []] takes the form of an array of points, where each point is an array of 3 floats, tupled with a list of numbers,
-# as well as several optional values.
+# See doc/payload.md for an example format of the payload
 func _on_remote_build_requested(id, msg: Dictionary) -> void:
 	print("[IPC] Remote build requested")
+	print(msg)
 	var path: String
 	var tpgn: String
 	if not msg.has("path") and not msg.has("tpgn"):

--- a/common/autoloads/protocol.gd
+++ b/common/autoloads/protocol.gd
@@ -35,8 +35,96 @@ func _on_data_received(id: int , data: Dictionary) -> void:
 		"build":
 			_on_remote_build_requested(id, data)
 
-
+# Input msg for the fence.tpgn graph will take the following form:
+# {
+# 	command:build, 
+# 	inputs: [{
+# 		node: [{
+# 			data: {
+# 				points: [
+# 					{ in:[0, 0, 0], out:[0, 0, 0], pos:[-4.35923, 0, -3.58755], tilt:0 }, 
+# 					{ in:[-3.83067, -0.005032, -0.890189], out:[3.83067, 0.005032, 0.890189], pos:[1.26936, 0.002264, -4.18087], tilt:0 }, 
+# 					{ in:[0.210581, 0, -1.57824], out:[-0.210581, 0, 1.57824], pos:[5.66448, 0, 1.26848], tilt:0 },
+# 					{ in:[0, 0, 0], out:[0, 0, 0], pos:[4.15667, 0, 4.50781], tilt:0 }
+# 				], 
+# 				transform: {
+# 					basis:[[1, 0, 0], [0, 1, 0], [0, 0, 1]], 
+# 					pos:[0, 0, 0]
+# 				}
+# 			}, 
+# 			name:Path,
+#			node_path_input:{Path:/root/EditorNode/@@592/@@593/@@601/@@603/@@607/@@611/@@612/@@613/@@629/@@630/@@639/@@640/@@6275/@@6109/@@6110/@@6111/@@6112/@@6113/TestProtongraph/Fence/Inputs/Path}
+# 			type:curve_3d
+# 		},
+# 		{
+# 			children:[{
+# 				children:[{
+# 					data:{
+# 						mesh:{
+# 							0:[[[ ... ]], Null, Null, Null, [ ... ]] /// (see below)
+# 						},
+# 						resource_path:res://assets/fences/models/fence_planks.glb::2,
+# 						transform:{
+# 							basis:[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+# 							pos:[0, -0.05, 0]
+# 						}
+# 					},
+# 					name:fence_planks,
+#					node_path_input:{fence_planks:/root/EditorNode/@@592/@@593/@@601/@@603/@@607/@@611/@@612/@@613/@@629/@@630/@@639/@@640/@@6275/@@6109/@@6110/@@6111/@@6112/@@6113/TestProtongraph/Fence/Inputs/fence_planks/tmpParent/fence_planks}
+# 					type:mesh
+# 				}],
+# 				data: {
+# 					transform: {
+# 						basis:[[1, 0, 0], [0, 1, 0], [0, 0, 1]], pos:[0, 0, 0]
+# 					}
+# 				},
+# 				name:tmpParent,
+#				node_path_input:{tmpParent:/root/EditorNode/@@592/@@593/@@601/@@603/@@607/@@611/@@612/@@613/@@629/@@630/@@639/@@640/@@6275/@@6109/@@6110/@@6111/@@6112/@@6113/TestProtongraph/Fence/Inputs/fence_planks/tmpParent}
+# 				type:node_3d
+# 			}],
+# 			data: {
+# 				transform: {
+# 					basis:[[1, 0, 0], [0, 1, 0], [0, 0, 1]], pos:[0, 0, 0]
+# 				}
+# 			},
+# 			name:fence_planks,
+#			node_path_input:{fence_planks:/root/EditorNode/@@592/@@593/@@601/@@603/@@607/@@611/@@612/@@613/@@629/@@630/@@639/@@640/@@6275/@@6109/@@6110/@@6111/@@6112/@@6113/TestProtongraph/Fence/Inputs/fence_planks}
+# 			type:node_3d
+# 		}], 
+# 		resources:[{
+#			name:Path, 
+#			node_path_input:{
+#				Path:/root/EditorNode/@@592/@@593/@@601/@@603/@@607/@@611/@@612/@@613/@@629/@@630/@@639/@@640/@@6275/@@6109/@@6110/@@6111/@@6112/@@6113/TestProtongraph/Fence/Inputs/Path
+#			}
+#		}, 
+#		{
+#			children:[{
+#				children:[{
+#					name:fence_planks, 
+#					node_path_input:{
+#						fence_planks:/root/EditorNode/@@592/@@593/@@601/@@603/@@607/@@611/@@612/@@613/@@629/@@630/@@639/@@640/@@6275/@@6109/@@6110/@@6111/@@6112/@@6113/TestProtongraph/Fence/Inputs/fence_planks/tmpParent/fence_planks
+#					}
+#				}],
+#				name:tmpParent,
+#				node_path_input:{
+#					tmpParent:/root/EditorNode/@@592/@@593/@@601/@@603/@@607/@@611/@@612/@@613/@@629/@@630/@@639/@@640/@@6275/@@6109/@@6110/@@6111/@@6112/@@6113/TestProtongraph/Fence/Inputs/fence_planks/tmpParent
+#				}
+#			}],
+#			name:fence_planks,
+#			node_path_input:{
+#				fence_planks:/root/EditorNode/@@592/@@593/@@601/@@603/@@607/@@611/@@612/@@613/@@629/@@630/@@639/@@640/@@6275/@@6109/@@6110/@@6111/@@6112/@@6113/TestProtongraph/Fence/Inputs/fence_planks
+#			}
+#		}]
+# 	}],
+# 	inspector:[],
+# 	path:/Users/Chris/code/token-cjg/TestProtongraphProject/templates/fence.tpgn
+# }
+#
+#
+# Where 0:[[[ ... ]], []] takes the form of an array of points, where each point is an array of 3 floats, tupled with a list of numbers,
+# as well as several optional values.
 func _on_remote_build_requested(id, msg: Dictionary) -> void:
+	print("[IPC] Remote build requested")
 	if not msg.has("path"):
 		return
 

--- a/common/autoloads/remote_manager.gd
+++ b/common/autoloads/remote_manager.gd
@@ -44,7 +44,7 @@ func _set_resource_references(tpl: Template, inputs: Array, resource_references:
 	for input in inputs:
 		if input:
 			for resource_reference in resource_references:
-				if resource_reference && resource_reference["name"] == input.name && resource_reference["resource_path"]:
+				if resource_reference && resource_reference["name"] == input.name && "resource_path" in resource_reference:
 					tpl.set_remote_resource(input.name, child_transversal + [resource_reference.name], resource_reference["resource_path"])
 				else:
 					# Why "else" condition here at present? Decided a maximum of only one resource_reference per top level input for now (which is admittedly potentially unrealistic for advanced usecases); can be revised later.

--- a/common/autoloads/remote_manager.gd
+++ b/common/autoloads/remote_manager.gd
@@ -51,7 +51,7 @@ func _set_resource_references(tpl: Template, inputs: Array, resource_references:
 					_set_resource_references(tpl, inputs, resource_reference["children"], child_transversal + [resource_reference.name])
 
 
-func _on_build_requested(id: int, path: String, args: Dictionary) -> void:
+func _on_build_requested(id: int, path: String, tpgn: String, args: Dictionary) -> void:
 	var tpl: Template
 	if _peers.has(id):
 		tpl = _peers[id]["template"]
@@ -61,7 +61,12 @@ func _on_build_requested(id: int, path: String, args: Dictionary) -> void:
 		_peers[id] = {}
 		_peers[id]["template"] = tpl
 
-	if tpl._loaded_template_path != path:
+	# When Protongraph is deployed to the cloud, the idea is to pass in the entire template as a string,
+	# else if we're running locally, we'd like to pass in the template's path.
+	# (Passing in the local path is helpful when we are running Protongraph as an interactive application.)
+	if tpgn != "":
+		tpl.load_from_tpgn(tpgn)
+	elif path != "" and tpl._loaded_template_path != path:
 		tpl.load_from_file(path)
 
 	if not tpl._template_loaded:

--- a/common/static/serializer.gd
+++ b/common/static/serializer.gd
@@ -5,7 +5,7 @@ extends Node
 
 
 var _resources: Array
-var _serialized_resources: Dictionary
+var _serialized_resources: Array
 
 # _node_metadata consists of an array of Dictionaries of the form [ { fence_planks: <fence_planks_node_path> }, { Path: <Path_node_path> }]
 var _node_metadata: Array
@@ -35,7 +35,7 @@ var _serialized_node_metadata: Dictionary
 # }
 func serialize(nodes_with_references: Array) -> Dictionary:
 	var _resources = []
-	var _serialized_resources = {}
+	var _serialized_resources = []
 
 	var result: Dictionary = {
 		"resources": [],
@@ -286,24 +286,27 @@ func _deserialize_curve_3d(data: Dictionary) -> Path:
 
 func _serialize_resource_mesh(mesh: Mesh) -> Dictionary:
 	var data = {}
-	data = {
-		"surfaces": [],
-		"name": mesh.resource_name
-	}
+	if "resource_name" in mesh:
+		data = {
+			"surfaces": [],
+			"name": mesh.resource_name
+		}
 
-	if mesh is PlaceholderMesh:
-		data["placeholder_id"] = mesh.id
-	elif mesh is PrimitiveMesh:
-		data["surfaces"].push_back({
-			"material": null,
-			"geometry": _format_array(mesh.get_mesh_arrays())
-		})
-	else:
-		for i in mesh.get_surface_count():
+		if mesh is PlaceholderMesh:
+			data["placeholder_id"] = mesh.id
+		elif mesh is PrimitiveMesh:
 			data["surfaces"].push_back({
-			"material": null,
-			"geometry": _format_array(mesh.surface_get_arrays(i))
-		})
+				"material": null,
+				"geometry": _format_array(mesh.get_mesh_arrays())
+			})
+		else:
+			for i in mesh.get_surface_count():
+				data["surfaces"].push_back({
+				"material": null,
+				"geometry": _format_array(mesh.surface_get_arrays(i))
+			})
+	else:
+		print("WARNING: Mesh resource is missing resource name")
 
 	return data
 
@@ -312,18 +315,21 @@ func _deserialize_resource_mesh(data: Dictionary) -> Mesh:
 	var mesh = ArrayMesh.new()
 	mesh.resource_name = data["name"] if "name" in data else ""
 
-	for surface in data["surfaces"]:
-		var geometry = surface["geometry"]
-		var surface_arrays = []
-		surface_arrays.resize(Mesh.ARRAY_MAX)
-		surface_arrays[Mesh.ARRAY_VERTEX] = _to_pool(geometry[Mesh.ARRAY_VERTEX])
-		surface_arrays[Mesh.ARRAY_NORMAL] = _to_pool(geometry[Mesh.ARRAY_NORMAL])
-		surface_arrays[Mesh.ARRAY_TEX_UV] = _to_pool(geometry[Mesh.ARRAY_TEX_UV])
+	if "surfaces" in data:
+		for surface in data["surfaces"]:
+			var geometry = surface["geometry"]
+			var surface_arrays = []
+			surface_arrays.resize(Mesh.ARRAY_MAX)
+			surface_arrays[Mesh.ARRAY_VERTEX] = _to_pool(geometry[Mesh.ARRAY_VERTEX])
+			surface_arrays[Mesh.ARRAY_NORMAL] = _to_pool(geometry[Mesh.ARRAY_NORMAL])
+			surface_arrays[Mesh.ARRAY_TEX_UV] = _to_pool(geometry[Mesh.ARRAY_TEX_UV])
 
-		if geometry[Mesh.ARRAY_INDEX]:
-			surface_arrays[Mesh.ARRAY_INDEX] = PoolIntArray(geometry[Mesh.ARRAY_INDEX])
+			if geometry[Mesh.ARRAY_INDEX]:
+				surface_arrays[Mesh.ARRAY_INDEX] = PoolIntArray(geometry[Mesh.ARRAY_INDEX])
 
-		mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, surface_arrays)
+			mesh.add_surface_from_arrays(Mesh.PRIMITIVE_TRIANGLES, surface_arrays)
+	else:
+		print("WARNING: No surfaces in mesh")
 
 	return mesh
 

--- a/compile.sh
+++ b/compile.sh
@@ -1,0 +1,15 @@
+#!/bin/bash
+
+# This script compiles Protongraph so as to allow it to run headlessly within a docker container.
+# After you have run this script, you should be able to run Protongraph by executing the following command:
+#
+# "docker run protongraph"
+#
+# To shutdown the running container, run "docker ps -a" and "docker rm -f <container_id>"
+
+# Build the compile image for compilation
+docker build -f Dockerfile.compile . -t gcc-build
+# Run the compile image in order to build the required headless binary
+docker run --rm -v "$PWD":/usr/protongraph -w /usr/protongraph gcc-build make SHELL=/bin/bash
+# Build the protongraph headless runtime image
+make package_docker

--- a/compile.sh
+++ b/compile.sh
@@ -7,6 +7,8 @@
 #
 # To shutdown the running container, run "docker ps -a" and "docker rm -f <container_id>"
 
+# Obtain binaries (which are required to build the project or develop against it locally) if not present
+./scripts/obtain_binaries.sh
 # Build the compile image for compilation
 docker build -f Dockerfile.compile . -t gcc-build
 # Run the compile image in order to build the required headless binary

--- a/doc/payload.md
+++ b/doc/payload.md
@@ -1,0 +1,273 @@
+### Example payload for fence.tpgn
+
+```
+{
+	command:build, 
+	inputs: [{
+		node: [{
+			data: {
+				points: [
+					{ in:[0, 0, 0], out:[0, 0, 0], pos:[-4.35923, 0, -3.58755], tilt:0 }, 
+					{ in:[-3.83067, -0.005032, -0.890189], out:[3.83067, 0.005032, 0.890189], pos:[1.26936, 0.002264, -4.18087], tilt:0 }, 
+					{ in:[0.210581, 0, -1.57824], out:[-0.210581, 0, 1.57824], pos:[5.66448, 0, 1.26848], tilt:0 },
+					{ in:[0, 0, 0], out:[0, 0, 0], pos:[4.15667, 0, 4.50781], tilt:0 }
+				], 
+				transform: {
+					basis:[[1, 0, 0], [0, 1, 0], [0, 0, 1]], 
+					pos:[0, 0, 0]
+				}
+			}, 
+			name:Path,
+			node_path_input:{Path:/root/EditorNode/@@592/@@593/@@601/@@603/@@607/@@611/@@612/@@613/@@629/@@630/@@639/@@640/@@6275/@@6109/@@6110/@@6111/@@6112/@@6113/TestProtongraph/Fence/Inputs/Path}
+			type:curve_3d
+		},
+		{
+			children:[{
+				children:[{
+					data:{
+						mesh:{
+							0:[[[ ... ]], Null, Null, Null, [ ... ]] /// (see below)
+						},
+						resource_path:res://assets/fences/models/fence_planks.glb::2,
+						transform:{
+							basis:[[1, 0, 0], [0, 1, 0], [0, 0, 1]],
+							pos:[0, -0.05, 0]
+						}
+					},
+					name:fence_planks,
+					node_path_input:{fence_planks:/root/EditorNode/@@592/@@593/@@601/@@603/@@607/@@611/@@612/@@613/@@629/@@630/@@639/@@640/@@6275/@@6109/@@6110/@@6111/@@6112/@@6113/TestProtongraph/Fence/Inputs/fence_planks/tmpParent/fence_planks}
+					type:mesh
+				}],
+				data: {
+					transform: {
+						basis:[[1, 0, 0], [0, 1, 0], [0, 0, 1]], pos:[0, 0, 0]
+					}
+				},
+				name:tmpParent,
+				node_path_input:{tmpParent:/root/EditorNode/@@592/@@593/@@601/@@603/@@607/@@611/@@612/@@613/@@629/@@630/@@639/@@640/@@6275/@@6109/@@6110/@@6111/@@6112/@@6113/TestProtongraph/Fence/Inputs/fence_planks/tmpParent}
+				type:node_3d
+			}],
+			data: {
+				transform: {
+					basis:[[1, 0, 0], [0, 1, 0], [0, 0, 1]], pos:[0, 0, 0]
+				}
+			},
+			name:fence_planks,
+			node_path_input:{fence_planks:/root/EditorNode/@@592/@@593/@@601/@@603/@@607/@@611/@@612/@@613/@@629/@@630/@@639/@@640/@@6275/@@6109/@@6110/@@6111/@@6112/@@6113/TestProtongraph/Fence/Inputs/fence_planks}
+			type:node_3d
+		}], 
+		resources:[{
+			name:Path, 
+			node_path_input:{
+				Path:/root/EditorNode/@@592/@@593/@@601/@@603/@@607/@@611/@@612/@@613/@@629/@@630/@@639/@@640/@@6275/@@6109/@@6110/@@6111/@@6112/@@6113/TestProtongraph/Fence/Inputs/Path
+			}
+		}, 
+		{
+			children:[{
+				children:[{
+					name:fence_planks, 
+					node_path_input:{
+						fence_planks:/root/EditorNode/@@592/@@593/@@601/@@603/@@607/@@611/@@612/@@613/@@629/@@630/@@639/@@640/@@6275/@@6109/@@6110/@@6111/@@6112/@@6113/TestProtongraph/Fence/Inputs/fence_planks/tmpParent/fence_planks
+					}
+				}],
+				name:tmpParent,
+				node_path_input:{
+					tmpParent:/root/EditorNode/@@592/@@593/@@601/@@603/@@607/@@611/@@612/@@613/@@629/@@630/@@639/@@640/@@6275/@@6109/@@6110/@@6111/@@6112/@@6113/TestProtongraph/Fence/Inputs/fence_planks/tmpParent
+				}
+			}],
+			name:fence_planks,
+			node_path_input:{
+				fence_planks:/root/EditorNode/@@592/@@593/@@601/@@603/@@607/@@611/@@612/@@613/@@629/@@630/@@639/@@640/@@6275/@@6109/@@6110/@@6111/@@6112/@@6113/TestProtongraph/Fence/Inputs/fence_planks
+			}
+		}]
+	}],
+	inspector:[],
+	tpgn:{
+		"connections": [
+			{
+				"from": "GraphNode3",
+				"from_port": 0,
+				"to": "GraphNode6",
+				"to_port": 0
+			},
+			{
+				"from": "GraphNode7",
+				"from_port": 0,
+				"to": "GraphNode6",
+				"to_port": 1
+			},
+			{
+				"from": "GraphNode6",
+				"from_port": 0,
+				"to": "GraphNode5",
+				"to_port": 1
+			},
+			{
+				"from": "remote_input_curve_3d",
+				"from_port": 0,
+				"to": "GraphNode3",
+				"to_port": 0
+			},
+			{
+				"from": "remote_input_3d2",
+				"from_port": 0,
+				"to": "GraphNode5",
+				"to_port": 0
+			},
+			{
+				"from": "remote_input_3d_reference",
+				"from_port": 0,
+				"to": "remote_sync_and_post",
+				"to_port": 0
+			},
+			{
+				"from": "GraphNode5",
+				"from_port": 0,
+				"to": "remote_sync_and_post",
+				"to_port": 1
+			}
+		],
+		"editor": {
+			"offset_x": -676.35968,
+			"offset_y": -447.364838
+		},
+		"inspector": {},
+		"nodes": [
+			{
+				"data": {},
+				"editor": {
+					"inputs": {},
+					"offset_x": 120,
+					"offset_y": -160
+				},
+				"name": "GraphNode5",
+				"type": "duplicate_nodes"
+			},
+			{
+				"data": {},
+				"editor": {
+					"inputs": {
+						"0": {
+							"value": 0
+						},
+						"1": {
+							"value": 90
+						},
+						"2": {
+							"value": 0
+						}
+					},
+					"offset_x": -400,
+					"offset_y": 160
+				},
+				"name": "GraphNode7",
+				"type": "value_vector3"
+			},
+			{
+				"data": {},
+				"editor": {
+					"inputs": {
+						"1": {
+							"value": 1.086
+						},
+						"2": {
+							"value": 0
+						},
+						"3": {
+							"value": 1
+						},
+						"4": {
+							"value": true
+						}
+					},
+					"offset_x": -400,
+					"offset_y": -60
+				},
+				"name": "GraphNode3",
+				"type": "curve_sample_points_constant"
+			},
+			{
+				"data": {},
+				"editor": {
+					"inputs": {
+						"0": {
+							"value": "Path"
+						},
+						"1": {
+							"value": false
+						}
+					},
+					"offset_x": -780,
+					"offset_y": -40
+				},
+				"name": "remote_input_curve_3d",
+				"type": "remote_input_curve_3d"
+			},
+			{
+				"data": {},
+				"editor": {
+					"inputs": {
+						"0": {
+							"value": "fence_planks"
+						},
+						"1": {
+							"value": false
+						}
+					},
+					"offset_x": 100,
+					"offset_y": -420
+				},
+				"name": "remote_input_3d_reference",
+				"type": "remote_input_3d_reference"
+			},
+			{
+				"data": {},
+				"editor": {
+					"inputs": {
+						"0": {
+							"value": "fence_planks"
+						},
+						"1": {
+							"value": false
+						}
+					},
+					"offset_x": -200,
+					"offset_y": -240
+				},
+				"name": "remote_input_3d2",
+				"type": "remote_input_3d"
+			},
+			{
+				"data": {},
+				"editor": {
+					"inputs": {},
+					"offset_x": 580,
+					"offset_y": -220
+				},
+				"name": "remote_sync_and_post",
+				"type": "remote_sync_and_post"
+			},
+			{
+				"data": {},
+				"editor": {
+					"inputs": {
+						"1": {
+							"value": "(0, 0, 0)"
+						},
+						"2": {
+							"value": true
+						}
+					},
+					"offset_x": -120,
+					"offset_y": -80
+				},
+				"name": "GraphNode6",
+				"type": "rotate_transforms_offset"
+			}
+		]
+	}
+}
+```
+
+Where 0:[[[ ... ]], []] takes the form of an array of points, where each point is an array of 3 floats, tupled with a list of numbers,
+as well as several optional values.

--- a/export_presets.cfg
+++ b/export_presets.cfg
@@ -7,14 +7,14 @@ custom_features=""
 export_filter="all_resources"
 include_filter="*.json"
 exclude_filter="examples/*"
-export_path="../bin/ProtonGraph.x86_64"
+export_path="builds/linux/ProtonGraph.x86_64"
 script_export_mode=0
 script_encryption_key=""
 
 [preset.0.options]
 
-custom_template/debug="../build/linux/template.x11.debug"
-custom_template/release="../builds/linux/template.x11.release"
+custom_template/debug=""
+custom_template/release=""
 binary_format/64_bits=true
 binary_format/embed_pck=false
 texture_format/bptc=false
@@ -128,3 +128,28 @@ notarization/apple_team_id=""
 texture_format/s3tc=true
 texture_format/etc=false
 texture_format/etc2=false
+
+[preset.3]
+
+name="server"
+platform="Linux/X11"
+runnable=false
+custom_features="server"
+export_filter="all_resources"
+include_filter="*.json"
+exclude_filter="examples/*"
+export_path="builds/server/ProtonGraph.x86_64"
+script_export_mode=0
+script_encryption_key=""
+
+[preset.3.options]
+
+custom_template/debug=""
+custom_template/release=""
+binary_format/64_bits=true
+binary_format/embed_pck=false
+texture_format/bptc=false
+texture_format/s3tc=true
+texture_format/etc=false
+texture_format/etc2=false
+texture_format/no_bptc_fallbacks=true

--- a/native/compile_all.sh
+++ b/native/compile_all.sh
@@ -30,8 +30,17 @@ scons -j${threads} platform=$platform bits=64 debug_symbols=no target=$target
 # We'll need to repoint a dependency within the dynamic library to point to the relative path to wherever we are
 # executing the project.  At present I have set this relative to the root.  When eventually this is compiled to an
 # osx bundle we'll need to change this to be relative to the root of the bundle.
-cp lib/src/librdkafka.1.dylib bin/osx/librdkafka.1.dylib
-install_name_tool -change /usr/local/lib/librdkafka.1.dylib @executable_path/native/thirdparty/librdkafka/bin/osx/librdkafka.1.dylib bin/osx/librdkafka.dylib
+if [ ${1} == "osx" ]
+  then
+    cp lib/src/librdkafka.1.dylib bin/osx/librdkafka.1.dylib
+    install_name_tool -change /usr/local/lib/librdkafka.1.dylib @executable_path/native/thirdparty/librdkafka/bin/osx/librdkafka.1.dylib bin/osx/librdkafka.dylib
+fi
+
+if [ ${1} == "linux" ]
+  then
+    cp lib/src/librdkafka.so.1 bin/x11/librdkafka.so.1
+    patchelf --set-rpath '$ORIGIN' bin/x11/librdkafka.so
+fi
 
 # Make sure that we add the mesh optimizer.  nb, not sure that this is required any more? https://github.com/godotengine/godot/pull/47764 , https://github.com/protongraph/protongraph/issues/101
 cd ../mesh_optimizer

--- a/native/thirdparty/librdkafka/SConstruct
+++ b/native/thirdparty/librdkafka/SConstruct
@@ -38,7 +38,8 @@ opts.Add(PathVariable('target_name', 'The library name.', 'librdkafka', PathVari
 godot_headers_path = "../../godot-cpp/godot_headers/"
 cpp_bindings_path = "../../godot-cpp/"
 cpp_library = "libgodot-cpp"
-rdkafka_library = "librdkafka.dylib"
+rdkafka_library_osx = "librdkafka.dylib"
+rdkafka_library_linux = "librdkafka.so"
 rdkafka_bindings_path = "./lib/src/"
 
 # only support 64 at this time..
@@ -83,12 +84,11 @@ elif env['platform'] in ('x11', 'linux'):
     env['target_path'] += 'x11/'
     env['target_name'] += '.so'
     cpp_library += '.linux'
+    env.Append(LINKFLAGS=["-Wl,-z,origin", "-m64"]) # Important for ELF headers
     if env['target'] in ('debug', 'd'):
-        env.Append(CCFLAGS=['-fPIC', '-g3', '-Og'])
-        env.Append(CXXFLAGS=['-std=c++17'])
+        env.Append(CCFLAGS=['-fPIC', '-std=c++17', "-Wwrite-strings", '-g3', '-Og'])
     else:
-        env.Append(CCFLAGS=['-fPIC', '-g', '-O3'])
-        env.Append(CXXFLAGS=['-std=c++17'])
+        env.Append(CCFLAGS=['-fPIC', '-std=c++17', "-Wwrite-strings", '-g', '-O3'])
 
 elif env['platform'] == 'windows':
     env['target_path'] += 'win/'
@@ -139,7 +139,11 @@ cpp_library += '.' + str(bits)
 # make sure our binding library is properly includes
 env.Append(CPPPATH=['.', godot_headers_path, cpp_bindings_path + 'include/', cpp_bindings_path + 'include/core/', cpp_bindings_path + 'include/gen/'])
 env.Append(LIBPATH=[cpp_bindings_path + 'bin/', rdkafka_bindings_path])
-env.Append(LIBS=[cpp_library, rdkafka_library])
+
+if env['platform'] == 'linux':
+    env.Append(LIBS=[cpp_library, rdkafka_library_linux])
+elif env['platform'] == 'osx':
+    env.Append(LIBS=[cpp_library, rdkafka_library_osx])
 
 # tweak this if you want to use different folders, or more folders, to store your source code in.
 env.Append(CPPPATH=['./'])

--- a/native/thirdparty/librdkafka/gdnative/librdkafka.cpp
+++ b/native/thirdparty/librdkafka/gdnative/librdkafka.cpp
@@ -56,7 +56,7 @@ void LibRdKafka::produce(String gd_message) {
   char *message = (char *)gd_message.alloc_c_string();
 
   std::cout << "Producing to Kafka ..." << std::endl;
-  std::cout << "Message from front-end: " << message << std::endl;
+  // std::cout << "Message from front-end: " << message << std::endl;
 
   size_t len = strlen(message);
   rd_kafka_resp_err_t err;

--- a/native/thirdparty/librdkafka/gdnative/librdkafka.cpp
+++ b/native/thirdparty/librdkafka/gdnative/librdkafka.cpp
@@ -7,10 +7,12 @@
 #include <fstream>
 #include <sstream>
 #include "./utility.h"
+#include <atomic>
+#include <csignal>
 
 using namespace godot;
 
-static volatile sig_atomic_t run = 1;
+static volatile std::atomic_uint32_t run = 1;
 
 void sigterm(int sig) {
   run = 0;
@@ -141,6 +143,7 @@ retry:
 }
 
 void LibRdKafka::set_config() {
+  std::cout << "Reading variables from config file.\n" << std::endl;
   std::string config_file_name = "config/kafka.config";
   std::ifstream config_file(config_file_name.c_str());
   std::string line;
@@ -175,10 +178,11 @@ void LibRdKafka::set_config() {
     // We should indicate that there is no configuration set for Kafka.
     pw_config_not_found = true;
   }
-  std::cout << "Broker: " << pw_broker << std::endl;
-  std::cout << "Broker Password: " << pw_broker_password << std::endl;
-  std::cout << "Topic: " << pw_topic << std::endl;
-  std::cout << "Domain: " << pw_domain << std::endl;
+  // The following lines for debugging purposes only.
+  // std::cout << "Broker: " << pw_broker << std::endl;
+  // std::cout << "Broker Password: " << pw_broker_password << std::endl;
+  // std::cout << "Topic: " << pw_topic << std::endl;
+  // std::cout << "Domain: " << pw_domain << std::endl;
 }
 
 void LibRdKafka::set_secrets() {

--- a/native/thirdparty/librdkafka/lib/mklove/modules/configure.atomics
+++ b/native/thirdparty/librdkafka/lib/mklove/modules/configure.atomics
@@ -137,7 +137,7 @@ int64_t foo (int64_t i) {
 
 
     if [[ ! -z $_libs ]]; then
-        mkl_mkvar_append LDFLAGS LDFLAGS "-Wl,--as-needed"
+        mkl_mkvar_append LDFLAGS LDFLAGS "-Wl,-rpath,'\$\$ORIGIN',-Wl,-z,origin,--as-needed"
         mkl_mkvar_append LIBS LIBS "$_libs"
     fi
 

--- a/native/thirdparty/librdkafka/librdkafka.gdns
+++ b/native/thirdparty/librdkafka/librdkafka.gdns
@@ -1,6 +1,6 @@
 [gd_resource type="NativeScript" load_steps=2 format=2]
 
-[ext_resource path="res://librdkafka.tres" type="GDNativeLibrary" id=1]
+[ext_resource path="res://native/thirdparty/librdkafka/librdkafka.tres" type="GDNativeLibrary" id=1]
 
 [resource]
 class_name = "LibRdKafka"

--- a/native/thirdparty/librdkafka/librdkafka.tres
+++ b/native/thirdparty/librdkafka/librdkafka.tres
@@ -1,9 +1,11 @@
 [gd_resource type="GDNativeLibrary" format=2]
 
 [resource]
-entry/OSX.64 = "res://librdkafka.dylib"
-entry/Windows.64 = "res://librdkafka.dll"
-entry/X11.64 = "res://librdkafka.so"
+entry/OSX.64 = "res://native/thirdparty/librdkafka/bin/osx/librdkafka.dylib"
+entry/Windows.64 = "res://native/thirdparty/librdkafka/bin/win/librdkafka.dll"
+entry/X11.64 = "res://native/thirdparty/librdkafka/bin/x11/librdkafka.so"
+entry/Server = "res://native/thirdparty/librdkafka/bin/x11/librdkafka.so"
 dependency/OSX.64 = [  ]
 dependency/Windows.64 = [  ]
 dependency/X11.64 = [  ]
+dependency/Server.64 = [  ]

--- a/native/thirdparty/mesh_optimizer/mesh_optimizer.tres
+++ b/native/thirdparty/mesh_optimizer/mesh_optimizer.tres
@@ -4,6 +4,8 @@
 entry/OSX.64 = "res://native/thirdparty/mesh_optimizer/bin/osx/libmeshoptimizer.dylib"
 entry/Windows.64 = "res://native/thirdparty/mesh_optimizer/bin/win/libmeshoptimizer.dll"
 entry/X11.64 = "res://native/thirdparty/mesh_optimizer/bin/x11/libmeshoptimizer.so"
+entry/Server = "res://native/thirdparty/mesh_optimizer/bin/x11/libmeshoptimizer.so"
 dependency/OSX.64 = [  ]
 dependency/Windows.64 = [  ]
 dependency/X11.64 = [  ]
+dependency/Server.64 = [  ]

--- a/scripts/debug.sh
+++ b/scripts/debug.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+# Allows us to step into a running protongraph container and launch a shell.
+id=$(docker ps | grep protongraph | awk '{ print $1 }')
+docker exec -it $id /bin/bash

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,0 +1,12 @@
+#!/bin/bash
+
+if [ $1 == "stop" ]; then
+  processId=$(ps | grep "./godot\.osx" | cut -d " " -f2)
+  kill -9 $processId
+  processId=$(ps | grep "./godot\.osx" | cut -d " " -f1)
+  kill -9 $processId
+fi
+
+if [ $1 == "start" ]; then
+  ./godot.osx.3.4.2-stable.tools.64
+fi

--- a/scripts/dev.sh
+++ b/scripts/dev.sh
@@ -1,9 +1,7 @@
 #!/bin/bash
 
 if [ $1 == "stop" ]; then
-  processId=$(ps | grep "./godot\.osx" | cut -d " " -f2)
-  kill -9 $processId
-  processId=$(ps | grep "./godot\.osx" | cut -d " " -f1)
+  processId=$(ps | grep "./godot\.osx" | awk '{print $1}')
   kill -9 $processId
 fi
 

--- a/scripts/obtain_binaries.sh
+++ b/scripts/obtain_binaries.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+# Check if godot.osx.3.4.2-stable.tools.64 exists.
+if [ ! -f "./godot.osx.3.4.2-stable.tools.64" ]; then
+  echo "godot.osx.3.4.2-stable.tools.64 does not exist.  Obtaining binary."
+  curl -sS https://downloads.tuxfamily.org/godotengine/3.4.2/Godot_v3.4.2-stable_osx.universal.zip > osx.zip
+  unzip -o osx.zip -d dev
+  cp ./dev/Godot.app/Contents/MacOS/Godot godot.osx.3.4.2-stable.tools.64
+  rm osx.zip
+fi
+
+# Check if godot.linux.3.4.2-stable.headless.64 exists.
+if [ ! -f "./godot.linux.3.4.2-stable.headless.64" ]; then
+  echo "godot.linux.3.4.2-stable.headless.64 does not exist.  Obtaining binary."
+  curl -sS https://downloads.tuxfamily.org/godotengine/3.4.2/Godot_v3.4.2-stable_linux_headless.64.zip > linux.zip
+  unzip -o linux.zip -d dev
+  cp ./dev/Godot_v3.4.2-stable_linux_headless.64 godot.linux.3.4.2-stable.headless.64
+  rm linux.zip
+fi

--- a/scripts/start.sh
+++ b/scripts/start.sh
@@ -1,0 +1,2 @@
+#!/bin/bash
+docker run --name protongraph -p 4347:4347 --net=bridge protongraph

--- a/scripts/stop.sh
+++ b/scripts/stop.sh
@@ -1,0 +1,4 @@
+#!/bin/bash
+
+id=$(docker ps | grep protongraph | awk '{ print $1 }')
+docker stop $id && docker rm $id

--- a/ui/views/editor/components/nodes/components/string.gd
+++ b/ui/views/editor/components/nodes/components/string.gd
@@ -3,6 +3,7 @@ class_name StringComponent
 
 
 var template_path: String
+var template_content: String
 
 var _line_edit: LineEdit
 var _dropdown: OptionButton


### PR DESCRIPTION
## TLDR

This change allows for Protongraph to be compiled so as to run headlessly in a Docker container.  Running Protongraph this way allows a user to produce to Kafka (should they provide within the `config` folder a valid `kafka.config` and valid secrets if applicable for their Kafka process).

## Detail

This change adds:

* A Dockerfile.compile to provide an isolated build process, so that the linux tool chain is used to compile Protongraph,
* A Dockerfile to run the Protongraph process headlessly in linux,
* A number of optimisations to tooling, SConstruct, and make files to properly support linux compilation,
* Some changes to the Readme to indicate how this change impacts building Protongraph.

In particular, this should allow for one to be able to produce to Kafka when running this process locally.

To compile for Docker, run `./compile.sh`.  Scripts to start, stop and debug the process are in the `scripts` folder.

To compile for OsX as per previous pull request, run `make osx`.

## Synopsis

After this change, one can run Protongraph in default responder mode (wherein it runs locally and responds to messages from a local Godot game with sync-godot added as a plugin) or in Kafka producer mode.  

Default Responder mode is best if one plans to run Protongraph locally on a single machine along with eg a Godot game.

For the more advanced usecase for running in Kafka producer mode, one may wish to model things broadly as follows:

![protongraph](https://user-images.githubusercontent.com/1825818/160256272-52e3eadd-9713-46e0-b140-5172acbb187b.jpg)

Basically, send messages to a Signalling server, produce to Kafka, and then consume from Kafka and send messages via websocket to Protongraph (this process), then produce back to Kafka again for a Signalling server consumer to process, before sending back to the Signalling server, and then back to any connected clients.

To take full advantage of the capabilities of Protongraph when running in this mode, each and every process (save for the user-defined Client process, e.g. Godot game) should be deployed to the cloud.